### PR TITLE
Fix TF tree

### DIFF
--- a/xarm_description/config/default_urdf_arguments/xarm6.yaml
+++ b/xarm_description/config/default_urdf_arguments/xarm6.yaml
@@ -15,7 +15,7 @@ limited: false
 effort_control: false 
 velocity_control: false
 # urdf-related
-attach_to: 'world'
+attach_to: 'xarm_device' #TODO: this currently has to match the robot name in the URDF. Fix in gazebo to change frame id.
 attach_xyz: '0 0 0'
 attach_rpy: '0 0 0'
 create_attach_link: true

--- a/xarm_description/urdf/xarm_device.urdf.xacro
+++ b/xarm_description/urdf/xarm_device.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="UF_ROBOT">
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="xarm_device">
   <!-- macro for having property with the same name/value as an argument -->
   <xacro:macro name="define_arg_property" params="prop_name default">
     <xacro:arg name="${prop_name}" default="${default}"/>
@@ -80,6 +80,7 @@
     attach_to="${robot_spec['attach_to']}" 
     attach_xyz="${robot_spec['attach_xyz']}" 
     attach_rpy="${robot_spec['attach_rpy']}"
+    create_attach_link="${robot_spec['create_attach_link']}"
 
     mesh_suffix="${robot_spec['mesh_suffix']}" 
     kinematics_suffix="${robot_spec['kinematics_suffix']}" 

--- a/xarm_description/urdf/xarm_device_macro.xacro
+++ b/xarm_description/urdf/xarm_device_macro.xacro
@@ -78,7 +78,27 @@
         <child link="${prefix}link_base" />
         <origin xyz="${attach_xyz}" rpy="${attach_rpy}" />
       </joint>
+
     </xacro:if>
+
+    <link name="${prefix}make_kinematic">
+      <gazebo>
+        <kinematic>true</kinematic>
+      </gazebo>
+      <inertial>
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <mass value="100" />
+        <inertia
+          ixx="1.0" ixy="-3.5E-06" ixz="1.25E-05"
+          iyy="1.0" iyz="1.67E-06" izz="1.0" />
+      </inertial>
+    </link>
+
+    <joint name="${prefix}make_kinematic_joint" type="fixed">
+      <parent link="${prefix}link_base" />
+      <child link="${prefix}make_kinematic" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </joint>
 
     <xacro:if value="${effort_control}"> 
       <xacro:property name="hard_interface" value="EffortJointInterface" />

--- a/xarm_description/urdf/xarm_device_macro.xacro
+++ b/xarm_description/urdf/xarm_device_macro.xacro
@@ -81,25 +81,6 @@
 
     </xacro:if>
 
-    <link name="${prefix}make_kinematic">
-      <gazebo>
-        <kinematic>true</kinematic>
-      </gazebo>
-      <inertial>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
-        <mass value="100" />
-        <inertia
-          ixx="1.0" ixy="-3.5E-06" ixz="1.25E-05"
-          iyy="1.0" iyz="1.67E-06" izz="1.0" />
-      </inertial>
-    </link>
-
-    <joint name="${prefix}make_kinematic_joint" type="fixed">
-      <parent link="${prefix}link_base" />
-      <child link="${prefix}make_kinematic" />
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-    </joint>
-
     <xacro:if value="${effort_control}"> 
       <xacro:property name="hard_interface" value="EffortJointInterface" />
     </xacro:if>

--- a/xarm_description/urdf/xarm_device_macro.xacro
+++ b/xarm_description/urdf/xarm_device_macro.xacro
@@ -68,15 +68,17 @@
     <xacro:property name="new_model1300" value="${scope_parent_model1300}"/>
 
     <!-- add one world link if no 'attach_to' specified  -->
-    <xacro:if value="${attach_to == 'world' and create_attach_link}">
-      <link name="world" />
-    </xacro:if>
+    <xacro:if value="${attach_to != ''}"> 
+      <xacro:if value="${create_attach_link}">
+        <link name="${attach_to}" />
+      </xacro:if>
 
-    <joint name="${prefix}world_joint" type="fixed">
-      <parent link="${attach_to}" />
-      <child link="${prefix}link_base" />
-      <origin xyz="${attach_xyz}" rpy="${attach_rpy}" />
-    </joint>
+      <joint name="${prefix}world_joint" type="fixed">
+        <parent link="${attach_to}" />
+        <child link="${prefix}link_base" />
+        <origin xyz="${attach_xyz}" rpy="${attach_rpy}" />
+      </joint>
+    </xacro:if>
 
     <xacro:if value="${effort_control}"> 
       <xacro:property name="hard_interface" value="EffortJointInterface" />
@@ -303,6 +305,20 @@
     </xacro:if>
 
     <xacro:device_macro_end />
+    <gazebo>
+        <plugin filename="ignition-gazebo-pose-publisher-system" name="gz::sim::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_model_pose>true</publish_model_pose>
+            <publish_nested_model_pose>true</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <update_frequency>10</update_frequency>
+            <static_publisher>false</static_publisher>
+            <static_update_frequency>10</static_update_frequency>
+        </plugin>
+    </gazebo>
 
   </xacro:macro>
 </robot>

--- a/xarm_gazebo/launch/_robot_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_robot_beside_table_gazebo.launch.py
@@ -88,26 +88,46 @@ def get_per_robot_stack(robot_idx, load_controller):
     )
 
     # gazebo spawn entity node
-    gazebo_spawn_entity_node = Node(
-        package="ros_gz_sim",
-        executable="create",
+    # gazebo_spawn_entity_node = Node(
+    #     package="ros_gz_sim",
+    #     executable="create",
+    #     namespace=this_robot_namespace,
+    #     output='screen',
+    #     arguments=[
+    #         '-topic', f'robot_description',
+    #         '-allow_renaming', 'false',
+    #         '-x', str(0.0 + robot_idx * 0.4),
+    #         '-y', '-0.3',
+    #         '-z', '1.021',
+    #         '-Y', '1.571',
+    #         '-timeout', '10000',
+    #     ],
+    #     parameters=[{'use_sim_time': True}],
+    # )
+
+    # nodes_to_launch.append(
+    #     gazebo_spawn_entity_node,
+    # )
+
+    spawn_entity_test_node = Node(
+        package="keti_gz_utils",
+        executable="create_on_table",
         namespace=this_robot_namespace,
         output='screen',
-        arguments=[
-            '-topic', f'robot_description',
-            '-allow_renaming', 'false',
-            '-x', str(0.0 + robot_idx * 0.4),
-            '-y', '-0.3',
-            '-z', '1.021',
-            '-Y', '1.571',
-            '-timeout', '10000',
-        ],
-        parameters=[{'use_sim_time': True}],
+        # NOTE: this version uses parameters instead of CLI arguments.
+        # This leads to cleaner dependencies.
+        parameters=[{
+            'use_sim_time': True,
+            'topic': 'robot_description',
+            'allow_renaming': False,
+            'x': 0.0 + robot_idx * 0.4,
+            'y': -0.3,
+            'z': 1.021,
+            'Y': 1.571
+        }],
     )
 
-    nodes_to_launch.append(
-        gazebo_spawn_entity_node,
-    )
+    nodes_to_launch.append(spawn_entity_test_node)
 
     # # Load controllers
     controllers = [
@@ -151,7 +171,7 @@ def get_per_robot_stack(robot_idx, load_controller):
         nodes_to_launch.append(
             RegisterEventHandler(
                 event_handler=OnProcessExit(
-                    target_action=gazebo_spawn_entity_node,
+                    target_action=spawn_entity_test_node,
                     on_exit=load_controllers
                 )
             )

--- a/xarm_gazebo/launch/_robot_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_robot_beside_table_gazebo.launch.py
@@ -169,7 +169,7 @@ def generate_launch_description():
     gazebo_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('ros_gz_sim'), 'launch', 'gz_sim.launch.py'])),
         launch_arguments={
-            'gz_args': f'-v4 -r {world_sdf_path}',  
+            'gz_args': f' -r {world_sdf_path}',  
         }.items(),
     )
 
@@ -186,14 +186,26 @@ def generate_launch_description():
             [camera_namespace, '/camera_ired1@sensor_msgs/msg/Image@ignition.msgs.Image'],
             [camera_namespace, '/camera_ired2@sensor_msgs/msg/Image@ignition.msgs.Image'],
             '/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
-            '/model/sensor_d455/pose@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
+            '/model/realsense2_camera/pose@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
+            '/model/xarm_device/pose@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V',
         ]
     )
+
+    relay_nodes = [
+        Node(
+            package="topic_tools",
+            executable="relay",
+            arguments=[
+                f"/model/{source}/pose",
+                "/tf"
+            ]
+        ) for source in ["realsense2_camera", "xarm_device"]
+    ]
 
     nodes_to_launch = [
         gazebo_launch,
         parameters_bridge,
-    ]
+    ] + relay_nodes
 
     # Node for launching camera robot state publisher
     robot_state_publisher_node_camera = Node(

--- a/xarm_moveit_config/rviz/moveit.rviz
+++ b/xarm_moveit_config/rviz/moveit.rviz
@@ -325,7 +325,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: world
+    Fixed Frame: world_table
     Frame Rate: 30
   Name: root
   Tools:

--- a/xarm_moveit_config/rviz/planner.rviz
+++ b/xarm_moveit_config/rviz/planner.rviz
@@ -310,7 +310,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: world
+    Fixed Frame: world_table
     Frame Rate: 30
   Name: root
   Tools:

--- a/xarm_moveit_config/srdf/xarm.srdf.xacro
+++ b/xarm_moveit_config/srdf/xarm.srdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="UF_ROBOT">
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="xarm_device">
   <!-- parameters -->
   <xacro:arg name="prefix" default="" />
 

--- a/xarm_moveit_config/srdf/xarm_macro.srdf.xacro
+++ b/xarm_moveit_config/srdf/xarm_macro.srdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="xarm_srdf">
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="xarm_device">
   <xacro:macro name="xarm_macro_srdf" params="prefix:='' dof:=7 robot_type:='xarm'
     add_gripper:='false' add_vacuum_gripper:='false' add_bio_gripper:='false' add_other_geometry:='false' "> 
     <xacro:if value="${dof == 5}">


### PR DESCRIPTION
Here is a proposed fix for the TF tree.

- Remove joint between `world` and `base_link` in URDF.
- Use Gazebo `PosePublisher` to get ground truth pose from world to robot. This is bridged by `ros_gz_bridge`, and relayed to `/tf` topic.
- Add link matching the `name` attribute of the top-level `<robot>` tag in URDF. See also fix in `ExistentialRobotics/realsense_ros2`
- Use a specialized robot spawning util (see `create_on_table` in `keti_ws/src/keti_gz_utils`) for fixing robot to table. This converts URDF to SDF, and adds a joint between world->canonical link. 